### PR TITLE
Fix react import for react-native

### DIFF
--- a/src/AltNativeContainerLegacy.js
+++ b/src/AltNativeContainerLegacy.js
@@ -4,7 +4,7 @@
  *
  * @see AltContainer
  */
-import React from 'react'
+import React from 'react-native'
 import mixinContainer from './mixinContainer'
 import assign from 'object.assign'
 


### PR DESCRIPTION
Fixes the `AltNativeContainer` so it uses ReactNative instead of React.

Now matches the original (when included in the main repo):
https://github.com/goatslacker/alt/blob/v0.17.9/components/AltNativeContainer.js

I've tested this in a ReactNative app and works correctly.
