### PR TITLE
[Deps] Use semver range for `object.assign`

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/altjs/container",
   "dependencies": {
-    "object.assign": "4.0.1"
+    "object.assign": "^4.0.1"
   },
   "devDependencies": {
     "alt": "0.17.4",


### PR DESCRIPTION
Without this change, consumers of your module (like Airbnb) are blocked from deduping nonbreaking versions.

Deps should only ever be pinned via shrinkwrap at the app level.
